### PR TITLE
feat: batch messages & prompt templates

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -72,8 +72,6 @@ export class Daemon implements IDaemon {
   ) {
     this.modelApiKeys = {
       generationKey: opts.modelApiKeys.generationKey,
-      embeddingKey:
-        opts.modelApiKeys.embeddingKey ?? opts.modelApiKeys.generationKey,
     };
 
     this.keypair = opts.privateKey;
@@ -515,7 +513,7 @@ export class Daemon implements IDaemon {
       throw new Error("Character not found");
     }
 
-    if (!this.modelApiKeys.embeddingKey || !this.modelApiKeys.generationKey) {
+    if (!this.modelApiKeys.generationKey) {
       throw new Error("Model API keys not found");
     }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -14,7 +14,6 @@ import type { Keypair } from "@solana/web3.js";
 import {
   createMultiplePrompts,
   createPrompt,
-  generateEmbeddings,
   generateText,
   generateTextWithMessages,
 } from "./llm.js";

--- a/packages/daemon/src/templateParser.ts
+++ b/packages/daemon/src/templateParser.ts
@@ -1,0 +1,61 @@
+import type { IMessageLifecycle } from "./types";
+
+const MESSAGE_ALLOWED_VARIABLES = [
+  "name",
+  "identity",
+  "message",
+  "context",
+  "tools",
+] as const;
+
+type TemplateData = {
+  lifecycle: IMessageLifecycle;
+  message: { role: "user" | "assistant"; content: string };
+};
+
+type MessageAllowedVariable = (typeof MESSAGE_ALLOWED_VARIABLES)[number];
+
+function validateTemplate(template: string): string[] {
+  const variablePattern = /\{\{(\w+)\}\}/g;
+  const matches = Array.from(template.matchAll(variablePattern));
+  const usedVars = matches.map((match) => match[1]);
+
+  const invalidVars = usedVars.filter(
+    (v) => !MESSAGE_ALLOWED_VARIABLES.includes(v as MessageAllowedVariable)
+  );
+
+  return invalidVars;
+}
+
+export function parseTemplate(
+  data: TemplateData,
+  template: string
+): { role: "user" | "assistant"; content: string } {
+  const invalidVars = validateTemplate(template);
+  if (invalidVars.length > 0) {
+    throw new Error(
+      `Template contains invalid variables: ${invalidVars.join(", ")}`
+    );
+  }
+
+  const variableMap = {
+    name: data.lifecycle.daemonName,
+    identity: data.lifecycle.identityPrompt,
+    message: data.message,
+    context: data.lifecycle.context?.join("\n") ?? "",
+    tools: data.lifecycle.tools?.join("\n") ?? "",
+  };
+
+  return {
+    role: data.message.role,
+    content: template.replace(
+      /\{\{(\w+)\}\}/g,
+      (_, variable: MessageAllowedVariable) => {
+        if (MESSAGE_ALLOWED_VARIABLES.includes(variable)) {
+          return variableMap[variable] as string;
+        }
+        return `{{${variable}}}`;
+      }
+    ),
+  };
+}

--- a/packages/daemon/src/types.ts
+++ b/packages/daemon/src/types.ts
@@ -20,7 +20,7 @@ export type IHookLog = any;
 
 export const ZMessageLifecycle = z.object({
   daemonPubkey: z.string(),
-  message: z.string(),
+  message: z.string().or(z.array(z.string())),
   messageId: z.string(),
   createdAt: z.string(),
   approval: z.string(),
@@ -29,7 +29,7 @@ export const ZMessageLifecycle = z.object({
   identityPrompt: z.string().nullable(),
   context: z.array(z.string()).default([]),
   tools: z.array(z.string()).default([]),
-  generatedPrompt: z.string().default(""),
+  generatedPrompt: z.string().or(z.array(z.string())).default(""),
   output: z.string().default(""),
   hooks: z.array(ZHook).default([]),
   hooksLog: z.array(z.string()).default([]),


### PR DESCRIPTION
Introduces `.multipleMessages` to the Daemon class, which takes multiple messages (either from "user" or "assistant") and subsequently feeds all of the given messages into text generation. 

Additionally, this PR adds optional prompt overrides and templating. A user calling the `.message` or `.multipleMessages` methods can now specify options for `customSystemPrompt` and `customMessageTemplate`. 

`customSystemPrompt`:
Overrides the default system prompt.

`customMessageTemplate`:
Takes a template string for the relevant variables to be added in. Any omitted variables will not be included, and any extra variables will fail template validation. 